### PR TITLE
Fix commenting behaviour

### DIFF
--- a/fish.configuration.json
+++ b/fish.configuration.json
@@ -1,9 +1,9 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
+        "lineComment": "#",
         // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "/*", "*/" ]
+        //"blockComment": [ "/*", "*/" ]
     },
     // symbols used as brackets
     "brackets": [


### PR DESCRIPTION
Right now if I do `ctrl+/` on a line to comment it out, it prepends `//` instead of `#`.
This change fixes that.
